### PR TITLE
fix the error from lookupswitch and tableswitch

### DIFF
--- a/byte/app/src/main/java/hgu/isel/structure/attribute/type/code/CodeAttributeAnalyzer.java
+++ b/byte/app/src/main/java/hgu/isel/structure/attribute/type/code/CodeAttributeAnalyzer.java
@@ -1152,9 +1152,9 @@ public class CodeAttributeAnalyzer {
                     break;
                 case 0xab:
                     // lookupswitch instruction
-                    currentOffset = offset + totalOffset;
-                    padding = (4 - (currentOffset % 4)) % 4;
-                    System.out.println(padding);
+
+                    padding = (4 - (offset % 4)) % 4;
+                    System.out.println("padding: " + padding);
 
                     paddingBytes = Arrays.copyOfRange(codes, offset, offset + padding);
 
@@ -1163,8 +1163,11 @@ public class CodeAttributeAnalyzer {
                     defaultByte = Arrays.copyOfRange(codes, offset, offset + 4);
                     offset += 4;
 
+                    System.out.printf("%02X  %02X  %02X  %02X\n", defaultByte[0], defaultByte[1], defaultByte[2], defaultByte[3]);
+
                     byte[] pair = Arrays.copyOfRange(codes, offset, offset + 4);
                     offset += 4;
+                    System.out.printf("%02X  %02X  %02X  %02X\n", pair[0], pair[1], pair[2], pair[3]);
 
                     int pairCount = ((pair[0]) << 24) |
                             ((pair[1] & 0xFF) << 16) |
@@ -1378,10 +1381,8 @@ public class CodeAttributeAnalyzer {
                     break;
                 case 0xaa:
                     // tableswitch instruction
-                    currentOffset = offset + totalOffset;
-                    padding = (4 - (currentOffset % 4)) % 4;
 
-
+                    padding = (4 - (offset % 4)) % 4;
                     paddingBytes = Arrays.copyOfRange(codes, offset, offset + padding);
 
 

--- a/byte/app/src/test/java/org/example/ByteTokTest.java
+++ b/byte/app/src/test/java/org/example/ByteTokTest.java
@@ -196,4 +196,24 @@ class ByteTokTest {
         assertDoesNotThrow(() -> classUnderTest.run("/Users/ehdrb01/Desktop/HGU/capstone/ByteParser/byte/app/src/codes/QueryValidator.class"));
     }
 
+    @Test void test41() {
+        ByteTok classUnderTest = new ByteTok();
+        assertDoesNotThrow(() -> classUnderTest.run("/Users/ehdrb01/Desktop/HGU/capstone/ByteParser/byte/app/src/codes/DataValidator.class"));
+    }
+
+    @Test void test42() {
+        ByteTok classUnderTest = new ByteTok();
+        assertDoesNotThrow(() -> classUnderTest.run("/Users/ehdrb01/Desktop/HGU/capstone/ByteParser/byte/app/src/codes/OortMap.class"));
+    }
+
+    @Test void test43() {
+        ByteTok classUnderTest = new ByteTok();
+        assertDoesNotThrow(() -> classUnderTest.run("/Users/ehdrb01/Desktop/HGU/capstone/ByteParser/byte/app/src/codes/MovingWindowAggregator.class"));
+    }
+
+    @Test void test44() {
+        ByteTok classUnderTest = new ByteTok();
+        assertDoesNotThrow(() -> classUnderTest.run("/Users/ehdrb01/Desktop/HGU/capstone/ByteParser/byte/app/src/codes/OortList.class"));
+    }
+
 }


### PR DESCRIPTION
the reason is that I consider the entire offset, but it is the wrong way if I want to use that kinds of instructions, then I can just use the local offset